### PR TITLE
fix(sql): type_production VARCHAR(20) → VARCHAR(30)

### DIFF
--- a/database/sql/01-schema.sql
+++ b/database/sql/01-schema.sql
@@ -12,7 +12,7 @@ CREATE TABLE batiment_definition (
     code                    VARCHAR(50)    NOT NULL UNIQUE,
     nom                     VARCHAR(100)   NOT NULL,
     description             TEXT           NOT NULL,
-    type_production         VARCHAR(20)    NOT NULL,
+    type_production         VARCHAR(30)    NOT NULL,
     base_cout_metal         INTEGER        NOT NULL,
     base_cout_cristal       INTEGER        NOT NULL,
     base_cout_energie       INTEGER        NOT NULL,


### PR DESCRIPTION
## Problème

La colonne `type_production` de `batiment_definition` était définie en `VARCHAR(20)`.
La valeur `'stockage_metal_cristal'` fait 22 caractères → rejet PostgreSQL avant même l'évaluation du `CHECK` constraint.

## Correction

`VARCHAR(20)` → `VARCHAR(30)`, cohérent avec `type_bonus` sur `recherche_definition` (déjà à `VARCHAR(30)`).

## Test

Scripts testés sur PostgreSQL 16-alpine via Docker :
- `01-schema.sql` → toutes les tables créées ✅
- `02-seed.sql` → 5 bâtiments, 4 recherches, 1 admin insérés ✅
- `03-fixtures.sql` → 8 joueurs, 8 planètes, 30 bâtiments, 14 recherches, 4 files de construction ✅